### PR TITLE
Add comprehensive context.Context support throughout codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ loc/generate/RB_FIELDS.csv
 .idea/**
 .vscode/**
 test.sil
+
+# Generated test files
+[0-9]*.sil

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,419 @@
+package sil
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestSplitConcurrent_ContextCancellation tests that splitConcurrent respects context cancellation
+func TestSplitConcurrent_ContextCancellation(t *testing.T) {
+	// Create a large dataset to ensure processing takes some time
+	const numRows = 1000
+	rows := make([]interface{}, numRows)
+	for i := range rows {
+		rows[i] = ConcurrentTestStruct{ID: "id"}
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := splitConcurrent(ctx, rows, false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestSplitConcurrent_ContextTimeout tests that splitConcurrent respects context timeout
+func TestSplitConcurrent_ContextTimeout(t *testing.T) {
+	// Create a large dataset
+	const numRows = 10000
+	rows := make([]interface{}, numRows)
+	for i := range rows {
+		rows[i] = ConcurrentTestStruct{ID: "id"}
+	}
+
+	// Create a context with an extremely short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	defer cancel()
+
+	// Give it a moment to expire
+	time.Sleep(1 * time.Millisecond)
+
+	_, err := splitConcurrent(ctx, rows, false)
+	if err == nil {
+		t.Fatal("expected error from timed out context")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded error, got: %v", err)
+	}
+}
+
+// TestSplitWithContext_Cancellation tests the sequential path with context cancellation
+func TestSplitWithContext_Cancellation(t *testing.T) {
+	// Small dataset to trigger sequential processing
+	const numRows = 50
+	rows := make([]interface{}, numRows)
+	for i := range rows {
+		rows[i] = ConcurrentTestStruct{ID: "id"}
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := splitWithContext(ctx, rows, false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestMarshalConcurrent_ContextCancellation tests that MarshalConcurrent respects context cancellation
+func TestMarshalConcurrent_ContextCancellation(t *testing.T) {
+	m := make(Multi)
+	// Create multiple tables
+	for i := 0; i < 5; i++ {
+		tableName := string(rune('A' + i))
+		m.Make(tableName, ConcurrentTestStruct{})
+		for j := 0; j < 100; j++ {
+			m.AppendView(tableName, ConcurrentTestStruct{ID: "row"})
+		}
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.MarshalConcurrent(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestMarshalWithContext_Cancellation tests that MarshalWithContext respects context cancellation
+func TestMarshalWithContext_Cancellation(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+	for i := 0; i < 100; i++ {
+		s.View.Data = append(s.View.Data, ConcurrentTestStruct{ID: "row"})
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.MarshalWithContext(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestWriteContext_Cancellation tests that WriteContext respects context cancellation
+func TestWriteContext_Cancellation(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+	s.View.Data = append(s.View.Data, ConcurrentTestStruct{ID: "row"})
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	err := s.WriteContext(ctx, tempDir+"/test.sil", false, false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestMultiWriteContext_Cancellation tests that Multi.WriteContext respects context cancellation
+func TestMultiWriteContext_Cancellation(t *testing.T) {
+	m := make(Multi)
+	m.Make("TEST", ConcurrentTestStruct{})
+	m.AppendView("TEST", ConcurrentTestStruct{ID: "row"})
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	err := m.WriteContext(ctx, tempDir+"/test.sil", false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestWriteConcurrentContext_Cancellation tests that WriteConcurrentContext respects context cancellation
+func TestWriteConcurrentContext_Cancellation(t *testing.T) {
+	m := make(Multi)
+	for i := 0; i < 3; i++ {
+		tableName := string(rune('A' + i))
+		m.Make(tableName, ConcurrentTestStruct{})
+		m.AppendView(tableName, ConcurrentTestStruct{ID: "row"})
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	err := m.WriteConcurrentContext(ctx, tempDir+"/test.sil", false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestWriteSeparateConcurrentContext_Cancellation tests that WriteSeparateConcurrentContext respects context cancellation
+func TestWriteSeparateConcurrentContext_Cancellation(t *testing.T) {
+	m := make(Multi)
+	for i := 0; i < 3; i++ {
+		tableName := string(rune('A' + i))
+		m.Make(tableName, ConcurrentTestStruct{})
+		m.AppendView(tableName, ConcurrentTestStruct{ID: "row"})
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	results := m.WriteSeparateConcurrentContext(ctx, func(name string) string {
+		return tempDir + "/" + name + ".sil"
+	}, false)
+
+	// Should have at least one error result
+	hasError := false
+	for _, result := range results {
+		if result.Err != nil {
+			hasError = true
+			if !errors.Is(result.Err, context.Canceled) {
+				t.Errorf("expected context.Canceled error, got: %v", result.Err)
+			}
+		}
+	}
+	if !hasError {
+		t.Error("expected at least one error from cancelled context")
+	}
+}
+
+// TestMarshalWithOptsContext_Cancellation tests that MarshalWithOptsContext respects context cancellation
+func TestMarshalWithOptsContext_Cancellation(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+	for i := 0; i < 200; i++ {
+		s.View.Data = append(s.View.Data, ConcurrentTestStruct{ID: "row"})
+	}
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := s.MarshalWithOptsContext(ctx, MarshalOptions{Concurrent: true})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestContextCancellation_MidOperation tests cancellation during processing
+func TestContextCancellation_MidOperation(t *testing.T) {
+	// Create a large dataset
+	const numRows = 5000
+	rows := make([]interface{}, numRows)
+	for i := range rows {
+		rows[i] = ConcurrentTestStruct{ID: "id"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	// This should either complete successfully or return a context error
+	_, err := splitConcurrent(ctx, rows, false)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("unexpected error type: %v", err)
+		}
+	}
+	// It's okay if it succeeds (fast machine) or fails with context.Canceled
+}
+
+// TestMarshalWithContext_ValidContext tests that MarshalWithContext works with valid context
+func TestMarshalWithContext_ValidContext(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+	s.View.Data = append(s.View.Data, ConcurrentTestStruct{ID: "001"})
+
+	ctx := context.Background()
+	data, err := s.MarshalWithContext(ctx)
+	if err != nil {
+		t.Fatalf("MarshalWithContext with valid context returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty data")
+	}
+}
+
+// TestMarshalContextInclude tests the MarshalContextInclude method
+func TestMarshalContextInclude(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+	s.View.Data = append(s.View.Data, ConcurrentTestStruct{ID: "001"})
+
+	ctx := context.Background()
+	data, err := s.MarshalContextInclude(ctx, false)
+	if err != nil {
+		t.Fatalf("MarshalContextInclude returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty data")
+	}
+}
+
+// TestWriteFileContext_ValidContext tests writeFileContext with valid context
+func TestWriteFileContext_ValidContext(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	filename := tempDir + "/test.sil"
+	data := []byte("test data")
+
+	err := writeFileContext(ctx, filename, data, false)
+	if err != nil {
+		t.Fatalf("writeFileContext with valid context returned error: %v", err)
+	}
+}
+
+// TestWriteFileContext_Cancellation tests that writeFileContext respects context cancellation
+func TestWriteFileContext_Cancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	filename := tempDir + "/test.sil"
+	data := []byte("test data")
+
+	err := writeFileContext(ctx, filename, data, false)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestJSONContext_Cancellation tests that JSONContext respects context cancellation
+func TestJSONContext_Cancellation(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tempDir := t.TempDir()
+	err := s.JSONContext(ctx, tempDir+"/test.json")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestJSONContext_ValidContext tests that JSONContext works with valid context
+func TestJSONContext_ValidContext(t *testing.T) {
+	var s SIL
+	s.View.Name = "TEST"
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	err := s.JSONContext(ctx, tempDir+"/test.json")
+	if err != nil {
+		t.Fatalf("JSONContext with valid context returned error: %v", err)
+	}
+}
+
+// TestMultiMarshalWithContext_Cancellation tests that Multi.MarshalWithContext respects context cancellation
+func TestMultiMarshalWithContext_Cancellation(t *testing.T) {
+	m := make(Multi)
+	for i := 0; i < 3; i++ {
+		tableName := string(rune('A' + i))
+		m.Make(tableName, ConcurrentTestStruct{})
+		m.AppendView(tableName, ConcurrentTestStruct{ID: "row"})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := m.MarshalWithContext(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got: %v", err)
+	}
+}
+
+// TestMultiMarshalWithContext_ValidContext tests that Multi.MarshalWithContext works with valid context
+func TestMultiMarshalWithContext_ValidContext(t *testing.T) {
+	m := make(Multi)
+	m.Make("TEST", ConcurrentTestStruct{})
+	m.AppendView("TEST", ConcurrentTestStruct{ID: "row"})
+
+	ctx := context.Background()
+	data, err := m.MarshalWithContext(ctx)
+	if err != nil {
+		t.Fatalf("MarshalWithContext with valid context returned error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty data")
+	}
+}
+
+// TestContextDeadlineExceeded tests handling of context deadline exceeded
+func TestContextDeadlineExceeded(t *testing.T) {
+	const numRows = 1000
+	rows := make([]interface{}, numRows)
+	for i := range rows {
+		rows[i] = ConcurrentTestStruct{ID: "id"}
+	}
+
+	// Create a context with an expired deadline
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Hour))
+	defer cancel()
+
+	_, err := splitConcurrent(ctx, rows, false)
+	if err == nil {
+		t.Fatal("expected error from expired deadline context")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded error, got: %v", err)
+	}
+}

--- a/files.go
+++ b/files.go
@@ -2,17 +2,35 @@ package sil
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 )
 
 // Write writes a SIL to a file
+// Uses context.Background() for backwards compatibility
 func (s *SIL) Write(filename string, include bool, archive bool) error {
+	return s.WriteContext(context.Background(), filename, include, archive)
+}
+
+// WriteContext writes a SIL to a file with context support
+// The context can be used to cancel the operation
+func (s *SIL) WriteContext(ctx context.Context, filename string, include bool, archive bool) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// create the bytes of the SIL file
-	d, err := s.Marshal(include)
+	d, err := s.MarshalWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("sil bytes conversion error: %v", err)
+	}
+
+	// Check context after marshaling
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	f, err := os.Create(filename)
@@ -25,16 +43,25 @@ func (s *SIL) Write(filename string, include bool, archive bool) error {
 	if archive {
 		err = setArchive(filename)
 		if err != nil {
+			f.Close()
 			return fmt.Errorf("error trying to set archive bit for %s with err: %v", filename, err)
 		}
+	}
+
+	// Check context before writing
+	if err := ctx.Err(); err != nil {
+		f.Close()
+		return err
 	}
 
 	// Write the bytes to the file, this returns an int of bytes written
 	i, err := f.Write(d)
 
 	if err != nil {
+		f.Close()
 		return fmt.Errorf("could not write bytes to file %s with err: %w", filename, err)
 	} else if i != len(d) {
+		f.Close()
 		return fmt.Errorf("number of bytes writte to %s did not match length of sil bytes", filename)
 	}
 	// Close the file, otherwise the archive bit cannot be unset
@@ -53,12 +80,29 @@ func (s *SIL) Write(filename string, include bool, archive bool) error {
 	return nil
 }
 
-// Write writes a SIL to a file
+// Write writes a Multi to a file
+// Uses context.Background() for backwards compatibility
 func (m *Multi) Write(filename string, archive bool) error {
+	return m.WriteContext(context.Background(), filename, archive)
+}
+
+// WriteContext writes a Multi to a file with context support
+// The context can be used to cancel the operation
+func (m *Multi) WriteContext(ctx context.Context, filename string, archive bool) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// create the bytes of the SIL file
-	d, err := m.Marshal()
+	d, err := m.MarshalWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("sil bytes conversion error: %w", err)
+	}
+
+	// Check context after marshaling
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	f, err := os.Create(filename)
@@ -71,16 +115,25 @@ func (m *Multi) Write(filename string, archive bool) error {
 	if archive {
 		err = setArchive(filename)
 		if err != nil {
+			f.Close()
 			return fmt.Errorf("error trying to set archive bit for %s with err: %w", filename, err)
 		}
+	}
+
+	// Check context before writing
+	if err := ctx.Err(); err != nil {
+		f.Close()
+		return err
 	}
 
 	// Write the bytes to the file, this returns an int of bytes written
 	i, err := f.Write(d)
 
 	if err != nil {
+		f.Close()
 		return fmt.Errorf("could not write bytes to file %s with err: %w", filename, err)
 	} else if i != len(d) {
+		f.Close()
 		return fmt.Errorf("number of bytes writte to %s did not match length of sil bytes", filename)
 	}
 	// Close the file, otherwise the archive bit cannot be unset
@@ -100,9 +153,27 @@ func (m *Multi) Write(filename string, archive bool) error {
 }
 
 // JSON Creates a JSON file of the SIL file
+// Uses context.Background() for backwards compatibility
 func (s *SIL) JSON(filename string) error {
+	return s.JSONContext(context.Background(), filename)
+}
+
+// JSONContext creates a JSON file of the SIL file with context support
+// The context can be used to cancel the operation
+func (s *SIL) JSONContext(ctx context.Context, filename string) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	f, err := os.Create(filename)
 	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Check context before encoding
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 

--- a/section.go
+++ b/section.go
@@ -1,6 +1,7 @@
 package sil
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -8,35 +9,10 @@ import (
 // section is a view
 type section []row
 
-// spit needs to be reworked it currently will combine two parts as the same because its based on number of
-// elements instead of what elements are contained.
+// split processes rows sequentially. It uses context.Background() internally.
+// For context-aware splitting, use splitWithContext from concurrent.go
 func split(rows []interface{}, include bool) (map[string]section, error) {
-	var ssec section
-
-	// take every row and reflect it
-	for i := range rows {
-		var r row
-		// TODO: Handle this error but split needs to return an error then
-		err := r.make(rows[i], include)
-		if err != nil {
-			return nil, err
-		}
-		ssec = append(ssec, r)
-	}
-
-	secs := make(map[string]section)
-
-	for i := range ssec {
-		// make the name of the section for the map based on the fields
-		var key string
-		for x := range ssec[i].elems {
-			key = key + *ssec[i].elems[x].name
-		}
-
-		secs[key] = append(secs[key], ssec[i])
-	}
-
-	return secs, nil
+	return splitWithContext(context.Background(), rows, include)
 }
 
 // create makes the sil structure for each section

--- a/silread/reader.go
+++ b/silread/reader.go
@@ -1,10 +1,12 @@
 package silread
 
 import (
+	"context"
 	"fmt"
-	"github.com/kjbreil/loc-macro/pkg/script"
 	"io"
 	"reflect"
+
+	"github.com/kjbreil/loc-macro/pkg/script"
 )
 
 type Reader struct {
@@ -15,7 +17,20 @@ type Reader struct {
 	macros script.Script
 }
 
+// NewReader creates a new Reader from the given ReadSeekCloser
+// Uses context.Background() for backwards compatibility
 func NewReader(rs io.ReadSeekCloser) (*Reader, error) {
+	return NewReaderContext(context.Background(), rs)
+}
+
+// NewReaderContext creates a new Reader from the given ReadSeekCloser with context support
+// The context can be used to cancel the operation
+func NewReaderContext(ctx context.Context, rs io.ReadSeekCloser) (*Reader, error) {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	r := &Reader{
 		r: rs,
 	}
@@ -25,7 +40,7 @@ func NewReader(rs io.ReadSeekCloser) (*Reader, error) {
 	r.p = newParser(r.r)
 
 	// get the stats from the file
-	err = r.newStatsFromReader()
+	err = r.newStatsFromReaderWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +48,20 @@ func NewReader(rs io.ReadSeekCloser) (*Reader, error) {
 	return r, nil
 }
 
+// NewReaderOnly creates a new Reader from the given ReadSeekCloser, only allowing specific tables
+// Uses context.Background() for backwards compatibility
 func NewReaderOnly(rs io.ReadSeekCloser, validTables []string) (*Reader, error) {
+	return NewReaderOnlyContext(context.Background(), rs, validTables)
+}
+
+// NewReaderOnlyContext creates a new Reader from the given ReadSeekCloser, only allowing specific tables
+// The context can be used to cancel the operation
+func NewReaderOnlyContext(ctx context.Context, rs io.ReadSeekCloser, validTables []string) (*Reader, error) {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	r := &Reader{
 		r: rs,
 	}
@@ -43,7 +71,7 @@ func NewReaderOnly(rs io.ReadSeekCloser, validTables []string) (*Reader, error) 
 	r.p = newParser(r.r)
 
 	// get the stats from the file
-	err = r.newStatsFromReaderOnly(validTables)
+	err = r.newStatsFromReaderOnlyWithContext(ctx, validTables)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +83,20 @@ func (r *Reader) ClearReader() {
 	r.r = nil
 }
 
+// UnmarshalReader unmarshals data from a reader into a slice
+// Uses context.Background() for backwards compatibility
 func UnmarshalReader(r io.Reader, data any) error {
+	return UnmarshalReaderContext(context.Background(), r, data)
+}
+
+// UnmarshalReaderContext unmarshals data from a reader into a slice with context support
+// The context can be used to cancel the operation
+func UnmarshalReaderContext(ctx context.Context, r io.Reader, data any) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if reflect.TypeOf(data).Kind() != reflect.Ptr {
 		return fmt.Errorf("data needs to be a pointer to a slice")
 	}
@@ -70,13 +111,18 @@ func UnmarshalReader(r io.Reader, data any) error {
 	// make a channel of the type for datatype
 	dataChan := reflect.MakeChan(reflect.ChanOf(reflect.BothDir, dataType), 100)
 
-	err := UnmarshalReaderChan(r, dataChan.Interface())
+	err := UnmarshalReaderChanContext(ctx, r, dataChan.Interface())
 	if err != nil {
 		return err
 	}
 	viewDataSlice := reflect.MakeSlice(reflect.SliceOf(dataType), 0, 0)
 
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		v, ok := dataChan.Recv()
 		if !ok {
 			break
@@ -91,7 +137,20 @@ func UnmarshalReader(r io.Reader, data any) error {
 	return nil
 }
 
+// UnmarshalReaderChan unmarshals data from a reader into a channel
+// Uses context.Background() for backwards compatibility
 func UnmarshalReaderChan(r io.Reader, dataChan any) error {
+	return UnmarshalReaderChanContext(context.Background(), r, dataChan)
+}
+
+// UnmarshalReaderChanContext unmarshals data from a reader into a channel with context support
+// The context can be used to cancel the operation
+func UnmarshalReaderChanContext(ctx context.Context, r io.Reader, dataChan any) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if reflect.TypeOf(dataChan).Kind() != reflect.Chan {
 		return fmt.Errorf("data needs to be a channel")
 	}
@@ -99,12 +158,25 @@ func UnmarshalReaderChan(r io.Reader, dataChan any) error {
 	// make a new parser with the reader
 	p := newParser(r)
 
-	go p.decodeChan(dataChan)
+	go p.decodeChanWithContext(ctx, dataChan)
 
 	return nil
 }
 
+// UnmarshalReaderChan unmarshals data from the Reader into a channel
+// Uses context.Background() for backwards compatibility
 func (r *Reader) UnmarshalReaderChan(dataChan any) error {
+	return r.UnmarshalReaderChanContext(context.Background(), dataChan)
+}
+
+// UnmarshalReaderChanContext unmarshals data from the Reader into a channel with context support
+// The context can be used to cancel the operation
+func (r *Reader) UnmarshalReaderChanContext(ctx context.Context, dataChan any) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if reflect.TypeOf(dataChan).Kind() != reflect.Chan {
 		return fmt.Errorf("data needs to be a channel")
 	}
@@ -116,7 +188,7 @@ func (r *Reader) UnmarshalReaderChan(dataChan any) error {
 	// make a new parser with the reader
 	p := newParser(r.r)
 
-	go p.decodeChan(dataChan)
+	go p.decodeChanWithContext(ctx, dataChan)
 
 	return nil
 }


### PR DESCRIPTION
- Add context support to all concurrent operations (splitConcurrent,
  MarshalConcurrent, WriteSeparateConcurrent, WriteConcurrent)
- Add context support to file I/O operations (Write, WriteContext,
  JSON, JSONContext)
- Add context support to Multi and SIL Marshal methods with
  MarshalWithContext variants
- Add context support to silread package (NewReaderContext,
  UnmarshalReaderContext, GetStatsContext, etc.)
- Maintain backwards compatibility with non-context versions that
  use context.Background() internally
- Add 20+ new context cancellation and timeout tests
- Update existing tests to use context.Background()
- All tests pass with race detector